### PR TITLE
Species classification accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ A new Flutter project.
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
-
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+In order to use the Microsoft Species Classifier you have to add the config.json file to
+the assets folder. You also have to uncomment the '- assets/config.json' line in the
+pubspec.yaml file. config.json is in the git ignore file for your safety. :)

--- a/lib/screens/picture_details_screen/picture_details_screen.dart
+++ b/lib/screens/picture_details_screen/picture_details_screen.dart
@@ -46,7 +46,7 @@ class _PictureDetailsScreenState extends State<PictureDetailsScreen> {
 
   Future<void> _initScreenInfo() async {
     await _getAnimalName(widget.imagePath);
-    if (animalName != "") {
+    if (animalName != "Not recognized") {
       await _getAnimalDetails(animalName, kingdomName);
     }
     _detailsAreInitialized = true;

--- a/lib/screens/picture_details_screen/picture_details_screen.dart
+++ b/lib/screens/picture_details_screen/picture_details_screen.dart
@@ -46,7 +46,7 @@ class _PictureDetailsScreenState extends State<PictureDetailsScreen> {
 
   Future<void> _initScreenInfo() async {
     await _getAnimalName(widget.imagePath);
-    if (animalName != "no name") {
+    if (animalName != "") {
       await _getAnimalDetails(animalName, kingdomName);
     }
     _detailsAreInitialized = true;

--- a/lib/services/microsoft_species_classifier.dart
+++ b/lib/services/microsoft_species_classifier.dart
@@ -13,7 +13,7 @@ class MicrosoftSpeciesClassifier extends SpeciesClassifierAdaptor{
   };
 
   final queryParameters = {
-    'topK': '1',
+    'topK': '2',
     'predictMode': 'classifyAndDetect',
   };
 
@@ -37,12 +37,17 @@ class MicrosoftSpeciesClassifier extends SpeciesClassifierAdaptor{
 
   @override
   parseResponse(Response response) {
+    var kingdom = '';
+    var commonName = '';
     if (response.statusCode != 200) {
-      return 'no name';
+      return [kingdom, commonName];
     }
     final responseBody = json.decode(response.body);
-    final kingdom = responseBody['predictions'][0]['kingdom_common'];
-    final commonName = responseBody['predictions'][0]['species_common'];
+    final confidence = responseBody['predictions'][0]['confidence'] + responseBody['predictions'][1]['confidence'];
+    if (confidence >= 40) {
+      kingdom = responseBody['predictions'][0]['kingdom_common'];
+      commonName = responseBody['predictions'][0]['species_common'];
+    }
     return [kingdom, commonName];
   }
 }

--- a/lib/services/microsoft_species_classifier.dart
+++ b/lib/services/microsoft_species_classifier.dart
@@ -37,8 +37,8 @@ class MicrosoftSpeciesClassifier extends SpeciesClassifierAdaptor{
 
   @override
   parseResponse(Response response) {
-    var kingdom = '';
-    var commonName = '';
+    var kingdom = 'Not recognized';
+    var commonName = 'Not recognized';
     if (response.statusCode != 200) {
       return [kingdom, commonName];
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,8 @@ flutter:
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
     - assets/image.jpg
+  # Uncomment the following line to use Microsoft API
+  #  - assets/config.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.


### PR DESCRIPTION
Minor changes. The classifier will return an array of two empty strings when the sum of the confidences of the first two predictions is below 40. The reason I did the first two instead of just the first one is because sometimes the confidence is split pretty evenly for two closely related species. 40 seems kinda low but when I tried it out the classifier is pretty accurate even though the confidence is lowish. Although if the classifier is wrong it usually has confidence score below 10 for the top prediction so I don't think this will be a problem. I also added instructions for using the config.json file to the readme.